### PR TITLE
Adjust reverse portrait handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ And hope that they end up in the feature end up in the main repro at some point.
 
 ## Stuff i changed/added
 - Allow to enable background video play from with the PictureInPicturePlayer
+- When reverse portrait is of the player will no longer change its display mode to normal portrait mode when we flip the phone and we are in fullscreen.
 
 # PlatformPlayer
 

--- a/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/VideoDetailFragment.kt
+++ b/app/src/main/java/com/futo/platformplayer/fragment/mainactivity/main/VideoDetailFragment.kt
@@ -99,8 +99,9 @@ class VideoDetailFragment : MainFragment {
         val bypassRotationPrevention = Settings.instance.other.bypassRotationPrevention;
         val fullAutorotateLock = Settings.instance.playback.fullAutorotateLock
         val currentRequestedOrientation = a.requestedOrientation
+        val isReversePortraitAllowed = Settings.instance.playback.reversePortrait
         var currentOrientation = if (_currentOrientation == -1) currentRequestedOrientation else _currentOrientation
-        if (currentOrientation == ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT && !Settings.instance.playback.reversePortrait)
+        if (currentOrientation == ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT && !isReversePortraitAllowed)
             currentOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
         val isAutoRotate = Settings.instance.playback.isAutoRotate()
@@ -347,7 +348,7 @@ class VideoDetailFragment : MainFragment {
                 return true
             }
 
-            if (state == State.MAXIMIZED && isFullscreen && !Settings.instance.playback.fullscreenPortrait && (_currentOrientation == ActivityInfo.SCREEN_ORIENTATION_PORTRAIT || _currentOrientation == ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT)) {
+            if (state == State.MAXIMIZED && isFullscreen && !Settings.instance.playback.fullscreenPortrait && (_currentOrientation == ActivityInfo.SCREEN_ORIENTATION_PORTRAIT || (_currentOrientation == ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT && Settings.instance.playback.reversePortrait ))) {
                 _viewDetail?.setFullscreen(false)
                 return true
             }


### PR DESCRIPTION
We should not rotate the screen upside down when reverse portrait is disabled.
Imo the better handling is to keep the current orientation in that case